### PR TITLE
Add initial agent-based simulation prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Agent-Based Simulation Game
 
-Idle, emergent storytelling simulation using autonomous AI agents.
+This project contains a small prototype for an idle, emergent-storytelling simulation.
+Agents act autonomously over time using a simple behavior engine built with
+[mesa](https://github.com/projectmesa/mesa) and [simpy](https://simpy.readthedocs.io/).
+
+Run the simulation:
+
+```bash
+python main.py
+```
+
+Logs are written to `data/simulation.log`.

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,67 @@
+from mesa import Agent
+import logging
+
+
+class BaseAgent(Agent):
+    """Base class for all agents."""
+
+    def __init__(self, unique_id, model, name="Agent"):
+        super().__init__(unique_id, model)
+        self.name = name
+        self.stats = {
+            "strength": 5,
+            "endurance": 5,
+        }
+        self.inventory = {
+            "food": 3,
+            "water": 3,
+        }
+        self.behavior_stack = []
+        self.days_since_wander = 0
+
+    def log(self, message: str) -> None:
+        logging.info(f"{self.name}: {message}")
+
+    def consume_resources(self) -> None:
+        """Consume daily resources."""
+        self.inventory["food"] -= 1
+        self.inventory["water"] -= 1
+        self.log(
+            f"consumes food and water. Food: {self.inventory['food']}, Water: {self.inventory['water']}"
+        )
+
+    def evaluate_needs(self) -> None:
+        """Push behaviors based on needs or time."""
+        self.days_since_wander += 1
+        if (
+            self.inventory["food"] <= 0
+            or self.inventory["water"] <= 0
+            or self.days_since_wander >= 3
+        ):
+            if self.wander not in self.behavior_stack:
+                self.behavior_stack.append(self.wander)
+                self.days_since_wander = 0
+
+    def idle(self) -> None:
+        self.log("is idling.")
+
+    def wander(self) -> None:
+        self.log("wanders and finds some resources.")
+        self.inventory["food"] += 2
+        self.inventory["water"] += 2
+        self.log(
+            f"now has Food: {self.inventory['food']}, Water: {self.inventory['water']}"
+        )
+
+    def step(self) -> None:
+        """Perform one day of actions."""
+        # Consume resources at start of day
+        self.consume_resources()
+        # Determine next behaviors
+        self.evaluate_needs()
+
+        if not self.behavior_stack:
+            self.behavior_stack.append(self.idle)
+
+        behavior = self.behavior_stack.pop(0)
+        behavior()

--- a/agents/example_agent.py
+++ b/agents/example_agent.py
@@ -1,0 +1,8 @@
+from .base import BaseAgent
+
+
+class ExampleAgent(BaseAgent):
+    """A simple agent demonstrating basic behaviors."""
+
+    def __init__(self, unique_id, model, name="Wanderer"):
+        super().__init__(unique_id, model, name)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Core simulation package

--- a/core/simulation.py
+++ b/core/simulation.py
@@ -1,6 +1,44 @@
+import os
+import logging
+import simpy
+
+from .world import World
+
+
 class Simulation:
-    def __init__(self):
-        print("Simulation initialized")
+    """Main simulation controller running the world."""
+
+    SECONDS_PER_DAY = 20
+
+    def __init__(self, days: int | None = None, real_time: bool = True, factor: float = 1):
+        self.days = days
+        self._setup_logging()
+        logging.info("Simulation initialized")
+        if real_time:
+            self.env = simpy.rt.RealtimeEnvironment(factor=factor, strict=False)
+        else:
+            self.env = simpy.Environment()
+        self.world = World(self.env)
+
+    def _setup_logging(self) -> None:
+        os.makedirs("data", exist_ok=True)
+        logging.basicConfig(
+            filename=os.path.join("data", "simulation.log"),
+            level=logging.INFO,
+            format="%(asctime)s %(message)s",
+        )
+
+    def _day_process(self):
+        while True:
+            yield self.env.timeout(self.SECONDS_PER_DAY)
+            self.world.step()
+            if self.days is not None and self.world.day >= self.days:
+                break
 
     def run(self):
-        print("Simulation running...")
+        logging.info("Simulation running...")
+        self.env.process(self._day_process())
+        if self.days is not None:
+            self.env.run(until=self.SECONDS_PER_DAY * self.days + 0.1)
+        else:
+            self.env.run()

--- a/core/world.py
+++ b/core/world.py
@@ -1,0 +1,26 @@
+import logging
+from mesa import Model
+from mesa.time import RandomActivation
+from agents.example_agent import ExampleAgent
+
+
+class World(Model):
+    """The game world holding agents and progressing time."""
+
+    def __init__(self, env, num_agents: int = 1):
+        super().__init__()
+        self.env = env
+        self.schedule = RandomActivation(self)
+        self.day = 0
+        self.create_agents(num_agents)
+
+    def create_agents(self, num_agents: int) -> None:
+        for i in range(num_agents):
+            agent = ExampleAgent(i, self, name=f"Agent_{i}")
+            self.schedule.add(agent)
+            logging.info(f"Created {agent.name}")
+
+    def step(self) -> None:
+        self.day += 1
+        logging.info(f"--- Day {self.day} ---")
+        self.schedule.step()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,10 @@
 from core.simulation import Simulation
 
-if __name__ == "__main__":
-    sim = Simulation()
+
+def main() -> None:
+    sim = Simulation(days=10, real_time=False)
     sim.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder for future UI modules


### PR DESCRIPTION
## Summary
- implement simple agent class with basic behaviors
- build world and simulation loop with SimPy & mesa
- add placeholder packages for UI and core modules
- provide CLI to run simulation quickly
- document how to run

## Testing
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_6860c2df986c8329a9d24a3e339f2941