### PR TITLE
Add basic debug UI with Flask

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -1,0 +1,31 @@
+import threading
+from typing import List
+
+from .simulation import Simulation
+
+
+class SimulationController:
+    """Controller to manage the simulation instance."""
+
+    def __init__(self, days: int | None = None, real_time: bool = False):
+        self.sim = Simulation(days=days, real_time=real_time)
+        self.thread: threading.Thread | None = None
+        self.lock = threading.Lock()
+
+    def start(self) -> None:
+        """Start the simulation in a background thread."""
+        if self.thread and self.thread.is_alive():
+            return
+        self.thread = threading.Thread(target=self.sim.run, daemon=True)
+        self.thread.start()
+
+    def list_agents(self):
+        with self.lock:
+            return self.sim.list_agents()
+
+    def spawn_random_agent(self):
+        with self.lock:
+            return self.sim.spawn_random_agent()
+
+    def get_day(self) -> int:
+        return self.sim.get_day()

--- a/core/simulation.py
+++ b/core/simulation.py
@@ -19,6 +19,7 @@ class Simulation:
         else:
             self.env = simpy.Environment()
         self.world = World(self.env)
+        self.running = False
 
     def _setup_logging(self) -> None:
         os.makedirs("data", exist_ok=True)
@@ -38,7 +39,18 @@ class Simulation:
     def run(self):
         logging.info("Simulation running...")
         self.env.process(self._day_process())
+        self.running = True
         if self.days is not None:
             self.env.run(until=self.SECONDS_PER_DAY * self.days + 0.1)
         else:
             self.env.run()
+        self.running = False
+
+    def spawn_random_agent(self):
+        return self.world.spawn_random_agent()
+
+    def list_agents(self):
+        return self.world.list_agents()
+
+    def get_day(self) -> int:
+        return self.world.day

--- a/core/world.py
+++ b/core/world.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from mesa import Model
 from mesa.time import RandomActivation
 from agents.example_agent import ExampleAgent
@@ -12,13 +13,33 @@ class World(Model):
         self.env = env
         self.schedule = RandomActivation(self)
         self.day = 0
+        self.next_id = 0
+        self.name_pool = [
+            "Aiden",
+            "Zara",
+            "Kai",
+            "Luna",
+            "Orion",
+            "Nova",
+        ]
         self.create_agents(num_agents)
 
     def create_agents(self, num_agents: int) -> None:
-        for i in range(num_agents):
-            agent = ExampleAgent(i, self, name=f"Agent_{i}")
-            self.schedule.add(agent)
-            logging.info(f"Created {agent.name}")
+        for _ in range(num_agents):
+            self.spawn_random_agent()
+
+    def list_agents(self):
+        return list(self.schedule.agents)
+
+    def spawn_random_agent(self) -> ExampleAgent:
+        name = random.choice(self.name_pool)
+        agent = ExampleAgent(self.next_id, self, name=name)
+        agent.stats["strength"] = random.randint(1, 10)
+        agent.stats["endurance"] = random.randint(1, 10)
+        self.schedule.add(agent)
+        logging.info(f"Created {agent.name} (id {self.next_id})")
+        self.next_id += 1
+        return agent
 
     def step(self) -> None:
         self.day += 1

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,43 @@
+from flask import Flask, jsonify
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.controller import SimulationController
+
+controller = SimulationController(real_time=True)
+controller.start()
+
+app = Flask(__name__)
+
+
+def agent_to_dict(agent):
+    behavior = agent.behavior_stack[0].__name__ if agent.behavior_stack else "idle"
+    return {
+        "id": agent.unique_id,
+        "name": agent.name,
+        "behavior": behavior,
+        "stats": agent.stats,
+    }
+
+
+@app.route("/agents")
+def list_agents():
+    agents = [agent_to_dict(a) for a in controller.list_agents()]
+    return jsonify(agents)
+
+
+@app.route("/time")
+def get_time():
+    return jsonify({"day": controller.get_day()})
+
+
+@app.post("/debug/spawn-agent")
+def spawn_agent():
+    agent = controller.spawn_random_agent()
+    return jsonify({"message": "spawned", "id": agent.unique_id, "name": agent.name})
+
+
+if __name__ == "__main__":
+    app.run(debug=True, use_reloader=False)


### PR DESCRIPTION
## Summary
- spawn randomized agents in `World`
- manage the simulation in new `SimulationController`
- expose helper functions in `Simulation`
- create Flask UI with routes for `/agents`, `/time`, and `/debug/spawn-agent`

## Testing
- `python -m py_compile core/controller.py core/simulation.py core/world.py ui/app.py`
- `timeout 10 python ui/app.py` *(manual curl to `/time` and `/agents`)*

------
https://chatgpt.com/codex/tasks/task_e_6860c81c9f148329bc178f6081692ae6